### PR TITLE
改进：转发udp，减少报错

### DIFF
--- a/update_nft.sh
+++ b/update_nft.sh
@@ -30,9 +30,9 @@ if [ "$qb_ip_addr" = "" ];then
     # redirect the udp
     nft add rule inet qbit_redirect prerouting udp dport $private_port redirect to :$public_port
     # set the rules allow allow tcp and udp into the public_port
-    nft 'add chain inet qbit_redirect INPUT { type filter hook input priority 0; policy drop;}'
-    nft add rule inet qbit_redirect INPUT tcp dport $public_port accept
-    nft add rule inet qbit_redirect INPUT udp dport $public_port accept
+    #nft 'add chain inet qbit_redirect INPUT { type filter hook input priority 0; policy drop;}'
+    #nft add rule inet qbit_redirect INPUT tcp dport $public_port accept
+    #nft add rule inet qbit_redirect INPUT udp dport $public_port accept
 else
     nft add rule inet qbit_redirect prerouting tcp dport $private_port dnat to $qb_ip_addr:$public_port
     # redirect the udp

--- a/update_nft.sh
+++ b/update_nft.sh
@@ -22,13 +22,13 @@ echo "Update nftables..."
 
 # Use nftables to forward traffic.
 nft delete table qbit_redirect
-nft add table ip qbit_redirect
-nft 'add chain ip qbit_redirect prerouting { type nat hook prerouting priority 0; }'
+nft add table inet qbit_redirect
+nft 'add chain inet qbit_redirect prerouting { type disnat hook prerouting priority -100; }'
 
 if [ "$qb_ip_addr" = "" ];then
-    nft add rule ip qbit_redirect prerouting tcp dport $private_port redirect to :$public_port
+    nft add rule inet qbit_redirect prerouting tcp dport $private_port redirect to :$public_port
 else
-    nft add rule ip qbit_redirect prerouting tcp dport $private_port dnat to $qb_ip_addr:$public_port
+    nft add rule inet qbit_redirect prerouting tcp dport $private_port dnat to $qb_ip_addr:$public_port
 fi
 
 echo "Done."

--- a/update_nft.sh
+++ b/update_nft.sh
@@ -30,7 +30,7 @@ if [ "$qb_ip_addr" = "" ];then
     # redirect the udp
     nft add rule inet qbit_redirect prerouting udp dport $private_port redirect to :$public_port
     # set the rules allow allow tcp and udp into the public_port
-    nft 'add chain inet qbit_redirect INPUT { type fliter hook input priority 0; policy drop;}'
+    nft 'add chain inet qbit_redirect INPUT { type filter hook input priority 0; policy drop;}'
     nft add rule inet qbit_redirect INPUT tcp dport $public_port accept
     nft add rule inet qbit_redirect INPUT udp dport $public_port accept
 else

--- a/update_nft.sh
+++ b/update_nft.sh
@@ -29,10 +29,6 @@ if [ "$qb_ip_addr" = "" ];then
     nft add rule inet qbit_redirect prerouting tcp dport $private_port redirect to :$public_port
     # redirect the udp
     nft add rule inet qbit_redirect prerouting udp dport $private_port redirect to :$public_port
-    # set the rules allow allow tcp and udp into the public_port
-    #nft 'add chain inet qbit_redirect INPUT { type filter hook input priority 0; policy drop;}'
-    #nft add rule inet qbit_redirect INPUT tcp dport $public_port accept
-    #nft add rule inet qbit_redirect INPUT udp dport $public_port accept
 else
     nft add rule inet qbit_redirect prerouting tcp dport $private_port dnat to $qb_ip_addr:$public_port
     # redirect the udp

--- a/update_nft.sh
+++ b/update_nft.sh
@@ -23,7 +23,7 @@ echo "Update nftables..."
 # Use nftables to forward traffic.
 nft delete table qbit_redirect
 nft add table inet qbit_redirect
-nft 'add chain inet qbit_redirect prerouting { type disnat hook prerouting priority -100; }'
+nft 'add chain inet qbit_redirect prerouting { type nat hook prerouting priority -100; }'
 
 if [ "$qb_ip_addr" = "" ];then
     nft add rule inet qbit_redirect prerouting tcp dport $private_port redirect to :$public_port

--- a/update_nft.sh
+++ b/update_nft.sh
@@ -21,6 +21,10 @@ curl -X POST -b "$qb_cookie" -d 'json={"listen_port":"'$public_port'"}' "$qb_add
 echo "Update nftables..."
 
 # Use nftables to forward traffic.
+if nft list tables | grep -q "qbit_redirect"; then
+    nft delete table qbit_redirect
+fi
+
 nft delete table qbit_redirect
 nft add table inet qbit_redirect
 nft 'add chain inet qbit_redirect prerouting { type nat hook prerouting priority -100; }' 

--- a/update_nft.sh
+++ b/update_nft.sh
@@ -23,12 +23,20 @@ echo "Update nftables..."
 # Use nftables to forward traffic.
 nft delete table qbit_redirect
 nft add table inet qbit_redirect
-nft 'add chain inet qbit_redirect prerouting { type nat hook prerouting priority -100; }'
+nft 'add chain inet qbit_redirect prerouting { type nat hook prerouting priority -100; }' 
 
 if [ "$qb_ip_addr" = "" ];then
     nft add rule inet qbit_redirect prerouting tcp dport $private_port redirect to :$public_port
+    # redirect the udp
+    nft add rule inet qbit_redirect prerouting udp dport $private_port redirect to :$public_port
+    # set the rules allow allow tcp and udp into the public_port
+    nft 'add chain inet qbit_redirect INPUT { type fliter hook input priority 0; policy drop;}'
+    nft add rule inet qbit_redirect INPUT tcp dport $public_port accept
+    nft add rule inet qbit_redirect INPUT udp dport $public_port accept
 else
     nft add rule inet qbit_redirect prerouting tcp dport $private_port dnat to $qb_ip_addr:$public_port
+    # redirect the udp
+    nft add rule inet qbit_redirect prerouting udp dport $private_port dnat to $qb_ip_addr:$public_port
 fi
 
 echo "Done."


### PR DESCRIPTION
1. 我记得bt除了tcp还会用udp，因此设置了udp转发
2. 在第一次执行nft delete命令时会报错（No such file)，因此我给delete 命令做了判断
3. 将ip 改为inet 以同时转发ipv6（虽然后来想想对于nat0的ipv6是多此一举）